### PR TITLE
Add two philosophy subpages and a general Articles page, update navbar

### DIFF
--- a/_site/articles.html
+++ b/_site/articles.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="General planned articles by Konstantinos Kontras."/>
+    <title>Articles | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Planned General Articles</h1>
+                    <p>A broader list of non-philosophy articles I plan to publish.</p>
+                    <ul>
+                        <li>How to structure a long-term research roadmap</li>
+                        <li>Lessons learned from interdisciplinary collaboration</li>
+                        <li>Communicating complex ideas to mixed audiences</li>
+                        <li>From prototype to publication: practical workflow notes</li>
+                        <li>Reading habits that improve research depth</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/_site/index.html
+++ b/_site/index.html
@@ -148,6 +148,18 @@
 <!--                        </li>-->
 
                         <li class="nav-item">
+                            <a class="nav-link " href="./philosophical-articles.html"><span>Philosophy Articles</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./philosophy-foundations.html"><span>Philosophy: Foundations</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./philosophy-mind-ai.html"><span>Philosophy: Mind &amp; AI</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./articles.html"><span>Articles</span></a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link " href="./#contact" data-target="#contact"><span>Contact</span></a>
                         </li>
                     </ul>

--- a/_site/philosophical-articles.html
+++ b/_site/philosophical-articles.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Planned philosophical articles by Konstantinos Kontras."/>
+    <title>Philosophical Articles | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Planned Philosophical Articles</h1>
+                    <p>This page tracks the philosophical articles I plan to write.</p>
+                    <ul>
+                        <li>The role of uncertainty in human decision-making</li>
+                        <li>What does it mean for a model to "understand"?</li>
+                        <li>Ethics of automation in scientific discovery</li>
+                        <li>Personal identity in the age of digital memory</li>
+                        <li>The limits of reductionism in cognition research</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/_site/philosophy-foundations.html
+++ b/_site/philosophy-foundations.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Foundational philosophy topics planned by Konstantinos Kontras."/>
+    <title>Philosophy Foundations | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Philosophy: Foundations</h1>
+                    <p>Core philosophy themes and long-form essays I plan to write.</p>
+                    <ul>
+                        <li>Knowledge, belief, and justified truth</li>
+                        <li>Free will, determinism, and responsibility</li>
+                        <li>Realism vs. instrumentalism in science</li>
+                        <li>The ethics of intellectual humility</li>
+                        <li>What counts as a good explanation?</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/_site/philosophy-mind-ai.html
+++ b/_site/philosophy-mind-ai.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Philosophy of mind and AI essays planned by Konstantinos Kontras."/>
+    <title>Philosophy of Mind and AI | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Philosophy: Mind & AI</h1>
+                    <p>A focused list of philosophy pieces around consciousness, intelligence, and AI.</p>
+                    <ul>
+                        <li>Consciousness and computational models</li>
+                        <li>Can machine representations have meaning?</li>
+                        <li>Embodiment and the limits of symbol manipulation</li>
+                        <li>Alignment as a philosophical problem</li>
+                        <li>Agency, intention, and autonomous systems</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="General planned articles by Konstantinos Kontras."/>
+    <title>Articles | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Planned General Articles</h1>
+                    <p>A broader list of non-philosophy articles I plan to publish.</p>
+                    <ul>
+                        <li>How to structure a long-term research roadmap</li>
+                        <li>Lessons learned from interdisciplinary collaboration</li>
+                        <li>Communicating complex ideas to mixed audiences</li>
+                        <li>From prototype to publication: practical workflow notes</li>
+                        <li>Reading habits that improve research depth</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -149,6 +149,18 @@
 <!--                        </li>-->
 
                         <li class="nav-item">
+                            <a class="nav-link " href="./philosophical-articles.html"><span>Philosophy Articles</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./philosophy-foundations.html"><span>Philosophy: Foundations</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./philosophy-mind-ai.html"><span>Philosophy: Mind &amp; AI</span></a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link " href="./articles.html"><span>Articles</span></a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link " href="./#contact" data-target="#contact"><span>Contact</span></a>
                         </li>
                     </ul>

--- a/philosophical-articles.html
+++ b/philosophical-articles.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Planned philosophical articles by Konstantinos Kontras."/>
+    <title>Philosophical Articles | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Planned Philosophical Articles</h1>
+                    <p>This page tracks the philosophical articles I plan to write.</p>
+                    <ul>
+                        <li>The role of uncertainty in human decision-making</li>
+                        <li>What does it mean for a model to "understand"?</li>
+                        <li>Ethics of automation in scientific discovery</li>
+                        <li>Personal identity in the age of digital memory</li>
+                        <li>The limits of reductionism in cognition research</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/philosophy-foundations.html
+++ b/philosophy-foundations.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Foundational philosophy topics planned by Konstantinos Kontras."/>
+    <title>Philosophy Foundations | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Philosophy: Foundations</h1>
+                    <p>Core philosophy themes and long-form essays I plan to write.</p>
+                    <ul>
+                        <li>Knowledge, belief, and justified truth</li>
+                        <li>Free will, determinism, and responsibility</li>
+                        <li>Realism vs. instrumentalism in science</li>
+                        <li>The ethics of intellectual humility</li>
+                        <li>What counts as a good explanation?</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>

--- a/philosophy-mind-ai.html
+++ b/philosophy-mind-ai.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="description" content="Philosophy of mind and AI essays planned by Konstantinos Kontras."/>
+    <title>Philosophy of Mind and AI | Konstantinos Kontras</title>
+    <link rel="stylesheet" href="./css/vendor-bundle.min.css" media="print" onload="this.media='all'">
+    <link rel="stylesheet" href="./css/wowchemy.css"/>
+    <link rel="stylesheet" href="./css/custom.css"/>
+</head>
+<body class="page-wrapper dark">
+<div class="page-header">
+    <header class="header--fixed">
+        <nav class="navbar navbar-expand-lg navbar-light compensate-for-scrollbar" id="navbar-main">
+            <div class="container-xl">
+                <a class="navbar-brand" href="./">Konstantinos Kontras</a>
+                <div class="navbar-collapse main-menu-item collapse show justify-content-start">
+                    <ul class="navbar-nav d-md-inline-flex">
+                        <li class="nav-item">
+                            <a class="nav-link" href="./">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophical-articles.html">Philosophy Articles</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./philosophy-foundations.html">Philosophy: Foundations</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link active" href="./philosophy-mind-ai.html">Philosophy: Mind & AI</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="./articles.html">Articles</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+</div>
+<div class="page-body" style="padding-top: 6rem;">
+    <section class="home-section">
+        <div class="container">
+            <div class="row justify-content-center">
+                <div class="col-12 col-lg-9">
+                    <h1>Philosophy: Mind & AI</h1>
+                    <p>A focused list of philosophy pieces around consciousness, intelligence, and AI.</p>
+                    <ul>
+                        <li>Consciousness and computational models</li>
+                        <li>Can machine representations have meaning?</li>
+                        <li>Embodiment and the limits of symbol manipulation</li>
+                        <li>Alignment as a philosophical problem</li>
+                        <li>Agency, intention, and autonomous systems</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Split the writing section into more specific destinations so philosophy material can be organized into focused subpages and a separate, more generic `Articles` page can hold non-philosophy pieces. 
- Make all writing sections discoverable from the main navigation so visitors can reach each list directly.

### Description
- Added `philosophy-foundations.html`, `philosophy-mind-ai.html`, and `articles.html` along with mirrored generated files in `_site/` to provide standalone pages for each section. 
- Kept the existing `philosophical-articles.html` page and updated its local nav to link to the new pages. 
- Updated `index.html` and `_site/index.html` to include navbar links for `Philosophy Articles`, `Philosophy: Foundations`, `Philosophy: Mind & AI`, and `Articles`. 
- Each page uses the site’s existing CSS (`./css/wowchemy.css`, `./css/custom.css`) and includes starter lists of planned pieces for the author.

### Testing
- Ran `git diff --check` and it reported no whitespace or formatting issues (success). 
- Served the site with `python3 -m http.server 4173 --directory /workspace/kkontras.github.io` and verified the new pages returned HTTP 200 (success). 
- Captured a Playwright screenshot of `philosophy-foundations.html` using a headless browser which completed successfully (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aabb80cb4833284295f070402abed)