### PR TITLE
Fix philosophy article theme consistency, heading contrast, and refs formatting

### DIFF
--- a/articles/philosophical/phmind_intelligence.html
+++ b/articles/philosophical/phmind_intelligence.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <title>Philosophical Article</title>
+  <meta name="description" content="Auto-rendered philosophical article from Markdown or TeX source."/>
+  <link rel="stylesheet" href="../../css/vendor-bundle.min.css"/>
+  <link rel="stylesheet" href="../../css/wowchemy.css"/>
+  <link rel="stylesheet" href="../../css/custom.css"/>
+  <style>
+    :root {
+      --page-bg: #f8fafc;
+      --text-main: #0f172a;
+      --text-subtle: #334155;
+      --card-bg: #ffffff;
+      --card-border: rgba(148, 163, 184, 0.35);
+      --link: #0ea5e9;
+      --link-hover: #0369a1;
+      --code-bg: #f1f5f9;
+      --error-bg: rgba(239, 68, 68, 0.1);
+      --error-border: rgba(239, 68, 68, 0.35);
+      --error-text: #991b1b;
+      --shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    }
+
+    body.dark-mode {
+      --page-bg: #0f172a;
+      --text-main: #e2e8f0;
+      --text-subtle: #cbd5e1;
+      --card-bg: rgba(15, 23, 42, 0.85);
+      --card-border: rgba(148, 163, 184, 0.25);
+      --link: #7dd3fc;
+      --link-hover: #bae6fd;
+      --code-bg: rgba(15, 23, 42, 0.95);
+      --error-bg: rgba(239, 68, 68, 0.15);
+      --error-border: rgba(239, 68, 68, 0.4);
+      --error-text: #fecaca;
+      --shadow: 0 12px 30px rgba(2, 6, 23, 0.35);
+    }
+
+    body {
+      background: var(--page-bg);
+      color: var(--text-main);
+      font-family: "Lato", sans-serif;
+      line-height: 1.75;
+      margin: 0;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .article-shell {
+      max-width: 900px;
+      margin: 36px auto;
+      padding: 0 24px 56px;
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 1rem;
+    }
+
+    .article-card {
+      background: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 14px;
+      padding: 32px;
+      box-shadow: var(--shadow);
+    }
+
+    h1 {
+      color: var(--text-main);
+      font-size: clamp(1.8rem, 2.8vw, 2.6rem);
+      margin-bottom: 0.75rem;
+    }
+
+    h2, h3, h4 {
+      color: var(--text-main);
+      margin-top: 2rem;
+      margin-bottom: 0.85rem;
+    }
+
+    p, li {
+      color: var(--text-subtle);
+    }
+
+    a { color: var(--link); }
+    a:hover { color: var(--link-hover); }
+
+    .back-link {
+      display: inline-block;
+      font-size: 0.95rem;
+      text-decoration: none;
+    }
+
+    .theme-toggle {
+      border: 1px solid var(--card-border);
+      background: var(--card-bg);
+      color: var(--text-main);
+      border-radius: 999px;
+      padding: 0.4rem 0.9rem;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+
+    .error {
+      background: var(--error-bg);
+      border: 1px solid var(--error-border);
+      border-radius: 10px;
+      padding: 14px;
+      color: var(--error-text);
+    }
+
+    pre {
+      background: var(--code-bg);
+      border-radius: 8px;
+      padding: 12px;
+      overflow-x: auto;
+      color: var(--text-main);
+    }
+
+    hr {
+      border-color: var(--card-border);
+    }
+
+    #article-root p:has(> a[id]) {
+      margin: 0;
+    }
+
+    #article-root .references-list {
+      margin-top: 0.5rem;
+      padding-left: 1.1rem;
+    }
+
+    #article-root .references-list li {
+      margin-bottom: 0.55rem;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <main class="article-shell">
+    <div class="toolbar">
+      <a class="back-link" href="../../index.html#philosophy">← Back to Philosophical Articles</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark and light mode">Switch to dark mode</button>
+    </div>
+    <article class="article-card">
+      <div id="article-root">Loading article…</div>
+    </article>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    (function () {
+      const storageKey = 'philosophy-article-theme';
+      const toggleButton = document.getElementById('theme-toggle');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const savedTheme = localStorage.getItem(storageKey);
+      const initialTheme = savedTheme || (prefersDark ? 'dark' : 'light');
+
+      function setTheme(theme) {
+        document.body.classList.toggle('dark-mode', theme === 'dark');
+        toggleButton.textContent = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+        localStorage.setItem(storageKey, theme);
+      }
+
+      setTheme(initialTheme);
+      toggleButton.addEventListener('click', function () {
+        const next = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+        setTheme(next);
+      });
+    })();
+  </script>
+
+  <script>
+    function formatReferences(root) {
+      const refsHeading = Array.from(root.querySelectorAll('h2, h3')).find((el) => el.textContent.trim().toLowerCase() === 'references');
+      if (!refsHeading) return;
+
+      let cursor = refsHeading.nextElementSibling;
+      if (!cursor || cursor.tagName.toLowerCase() !== 'p') return;
+
+      const html = cursor.innerHTML;
+      const matches = html.match(/<a id="[^"]+"><\/a>[^<]+(?:<em>[^<]*<\/em>[^<]*)?/g);
+      if (!matches || !matches.length) return;
+
+      const list = document.createElement('ol');
+      list.className = 'references-list';
+
+      matches.forEach((entry) => {
+        const li = document.createElement('li');
+        li.innerHTML = entry.trim();
+        list.appendChild(li);
+      });
+
+      cursor.replaceWith(list);
+    }
+
+    (async function () {
+      const root = document.getElementById('article-root');
+      const params = new URLSearchParams(window.location.search);
+      const source = params.get('src') || 'phmind_intelligence.md';
+      const extension = source.split('.').pop().toLowerCase();
+
+      try {
+        const response = await fetch(source);
+        if (!response.ok) throw new Error(`Failed to load ${source} (${response.status})`);
+        let raw = await response.text();
+
+        if (extension === 'md' || extension === 'markdown') {
+          raw = raw.replaceAll(' <a id="', '\n<a id="');
+          root.innerHTML = window.marked.parse(raw);
+          formatReferences(root);
+
+          const titleHeading = root.querySelector('h1');
+          if (titleHeading && titleHeading.textContent.trim()) {
+            document.title = titleHeading.textContent.trim();
+          }
+
+          if (window.MathJax && window.MathJax.typesetPromise) {
+            window.MathJax.typesetPromise([root]).catch(() => {});
+          }
+          return;
+        }
+
+        if (extension === 'tex') {
+          document.title = source;
+          root.innerHTML = `<h1>${source}</h1><p>TeX source preview:</p><pre>${raw
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')}</pre><p>Tip: for full TeX article conversion, add a build step (for example Pandoc) before deployment.</p>`;
+          return;
+        }
+
+        root.innerHTML = `<div class="error">Unsupported file type: <code>${extension}</code>. Please use <code>.md</code> or <code>.tex</code>.</div>`;
+      } catch (error) {
+        root.innerHTML = `<div class="error">Could not load article source <code>${source}</code>.<br/>${error.message}</div>`;
+      }
+    })();
+  </script>
+
+  <script>
+    window.MathJax = {
+      tex: { inlineMath: [['$', '$'], ['\\(', '\\)']], displayMath: [['$$', '$$'], ['\\[', '\\]']] }
+    };
+  </script>
+  <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
                         </div>
                         <div class="pub-content">
                             <div class="pub-title">
-                                <a href="phil_link">
+                                <a href="./articles/philosophical/phmind_intelligence.html?src=phmind_intelligence.md">
                                     The Metabolic Mind: Reclaiming the Conditions of Intelligence
                                 </a>
                             </div>


### PR DESCRIPTION
### Motivation
- Ensure the philosophical article renderer matches the site's light/dark aesthetics so the page background and card colors no longer differ from the rest of the site.
- Make headings readable in both themes by avoiding hardcoded dark text and explicitly sourcing heading colors from theme-aware variables.
- Render references as separate list items so citations are spaced and readable instead of being cramped in a single paragraph.
- Replace the dropdown-like theme control with an accessible button that reliably toggles theme and persists the preference.

### Description
- Added `articles/philosophical/phmind_intelligence.html` that uses CSS variables and a `body.dark-mode` variant to provide light/dark-aware styling for page background, card, text, links, and code blocks.
- Explicitly set heading colors (`h1`, `h2`, `h3`, `h4`) and paragraph/list colors to theme variables so titles remain visible in both themes.
- Replaced the previous theme control with a button `#theme-toggle` and JavaScript that uses `localStorage` and `prefers-color-scheme` to persist and apply `dark`/`light` modes, updating the button label on change.
- Improved reference handling by preprocessing Markdown (`raw.replaceAll(' <a id="', '\n<a id="')`) and post-processing the rendered DOM with `formatReferences(root)` to produce an ordered list `.references-list` with each citation as its own `li`.
- Updated the homepage article link in `index.html` to point to the renderer with an explicit source query: `./articles/philosophical/phmind_intelligence.html?src=phmind_intelligence.md`.

### Testing
- Ran `rg` to confirm presence of `theme-toggle`, `dark-mode`, `references-list`, and the Markdown preprocessing string, and this check succeeded.
- Served the site locally with `python -m http.server 4173` and fetched the article URL `http://127.0.0.1:4173/articles/philosophical/phmind_intelligence.html?src=phmind_intelligence.md` to verify the page loads, which succeeded.
- Executed Playwright scripts to capture screenshots of the page before and after clicking `#theme-toggle`, and both light and dark-mode screenshots were produced successfully.
- Verified the document title updates from the rendered `h1` and that MathJax typesetting is invoked when present, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab3339b608332bf590d6317b6140c)