### PR TITLE
Further soften light-mode surfaces; add philosophical article and simplify theme toggle

### DIFF
--- a/articles/philosophical/phmind_intelligence.html
+++ b/articles/philosophical/phmind_intelligence.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+  <title>Philosophical Article</title>
+  <meta name="description" content="Auto-rendered philosophical article from Markdown or TeX source."/>
+  <link rel="stylesheet" href="../../css/vendor-bundle.min.css"/>
+  <link rel="stylesheet" href="../../css/wowchemy.css"/>
+  <link rel="stylesheet" href="../../css/custom.css"/>
+  <style>
+    body.page-wrapper {
+      min-height: 100vh;
+    }
+
+    .article-shell {
+      max-width: 900px;
+      margin: 36px auto;
+      padding: 0 24px 56px;
+    }
+
+    .toolbar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 1rem;
+    }
+
+    .theme-icon-btn {
+      border: 0;
+      background: transparent;
+      color: inherit;
+      padding: 0.25rem 0.45rem;
+      border-radius: 0.25rem;
+      cursor: pointer;
+      line-height: 1;
+    }
+
+    .theme-icon-btn i {
+      font-size: 1.05rem;
+    }
+
+    .article-card {
+      background: #ffffff;
+      border: 1px solid rgba(15, 23, 42, 0.08);
+      border-radius: 14px;
+      padding: 32px;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+    }
+
+    body.dark .article-card {
+      background: rgba(15, 23, 42, 0.35);
+      border-color: rgba(148, 163, 184, 0.18);
+      box-shadow: 0 16px 40px rgba(2, 6, 23, 0.4);
+    }
+
+    body.dark h1,
+    body.dark h2,
+    body.dark h3,
+    body.dark h4 {
+      color: #e2e8f0;
+    }
+
+    body.dark p,
+    body.dark li {
+      color: #dbeafe;
+    }
+
+    .back-link {
+      display: inline-block;
+      font-size: 0.95rem;
+      text-decoration: none;
+    }
+
+    .error {
+      border-radius: 10px;
+      padding: 14px;
+    }
+
+    body.light .error {
+      background: rgba(239, 68, 68, 0.10);
+      border: 1px solid rgba(239, 68, 68, 0.35);
+      color: #991b1b;
+    }
+
+    body.dark .error {
+      background: rgba(239, 68, 68, 0.15);
+      border: 1px solid rgba(239, 68, 68, 0.4);
+      color: #fecaca;
+    }
+
+    #article-root .references-list {
+      margin-top: 0.5rem;
+      padding-left: 1.1rem;
+    }
+
+    #article-root .references-list li {
+      margin-bottom: 0.7rem;
+      line-height: 1.65;
+    }
+
+    pre {
+      border-radius: 8px;
+      padding: 12px;
+      overflow-x: auto;
+    }
+
+    body.light pre {
+      background: #f1f5f9;
+    }
+
+    body.dark pre {
+      background: rgba(15, 23, 42, 0.95);
+      color: #e2e8f0;
+    }
+  </style>
+</head>
+<body id="top" class="page-wrapper dark">
+  <main class="article-shell">
+    <div class="toolbar">
+      <a class="back-link" href="../../index.html#philosophy">← Back to Philosophical Articles</a>
+      <button id="theme-toggle" class="theme-icon-btn" type="button" aria-label="Toggle dark and light mode" title="Toggle dark/light mode">
+        <i id="theme-toggle-icon" class="fas fa-sun" aria-hidden="true"></i>
+      </button>
+    </div>
+    <article class="article-card article-style">
+      <div id="article-root">Loading article…</div>
+    </article>
+  </main>
+
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script>
+    (function () {
+      const storageKey = 'philosophy-article-theme';
+      const toggleButton = document.getElementById('theme-toggle');
+      const icon = document.getElementById('theme-toggle-icon');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const savedTheme = localStorage.getItem(storageKey);
+      const initialTheme = savedTheme || (prefersDark ? 'dark' : 'light');
+
+      function setTheme(theme) {
+        document.body.classList.remove('dark', 'light');
+        document.body.classList.add(theme);
+        icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+        toggleButton.title = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+        localStorage.setItem(storageKey, theme);
+      }
+
+      setTheme(initialTheme);
+      toggleButton.addEventListener('click', function () {
+        const next = document.body.classList.contains('dark') ? 'light' : 'dark';
+        setTheme(next);
+      });
+    })();
+  </script>
+
+  <script>
+    function formatReferences(root) {
+      const refsHeading = Array.from(root.querySelectorAll('h2, h3')).find((el) => el.textContent.trim().toLowerCase() === 'references');
+      if (!refsHeading) return;
+
+      let cursor = refsHeading.nextElementSibling;
+      if (!cursor || cursor.tagName.toLowerCase() !== 'p') return;
+
+      const html = cursor.innerHTML;
+      const chunks = html
+        .split(/(?=<a id="[^"]+"><\/a>)/g)
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+      if (!chunks.length) return;
+
+      const list = document.createElement('ol');
+      list.className = 'references-list';
+
+      chunks.forEach((entry) => {
+        const li = document.createElement('li');
+        li.innerHTML = entry;
+        list.appendChild(li);
+      });
+
+      cursor.replaceWith(list);
+    }
+
+    (async function () {
+      const root = document.getElementById('article-root');
+      const params = new URLSearchParams(window.location.search);
+      const source = params.get('src') || 'phmind_intelligence.md';
+      const extension = source.split('.').pop().toLowerCase();
+
+      try {
+        const response = await fetch(source);
+        if (!response.ok) throw new Error(`Failed to load ${source} (${response.status})`);
+        let raw = await response.text();
+
+        if (extension === 'md' || extension === 'markdown') {
+          raw = raw.replaceAll(' <a id="', '\n<a id="');
+          root.innerHTML = window.marked.parse(raw);
+          formatReferences(root);
+
+          const titleHeading = root.querySelector('h1');
+          if (titleHeading && titleHeading.textContent.trim()) {
+            document.title = titleHeading.textContent.trim();
+          }
+
+          if (window.MathJax && window.MathJax.typesetPromise) {
+            window.MathJax.typesetPromise([root]).catch(() => {});
+          }
+          return;
+        }
+
+        if (extension === 'tex') {
+          document.title = source;
+          root.innerHTML = `<h1>${source}</h1><p>TeX source preview:</p><pre>${raw
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')}</pre><p>Tip: for full TeX article conversion, add a build step (for example Pandoc) before deployment.</p>`;
+          return;
+        }
+
+        root.innerHTML = `<div class="error">Unsupported file type: <code>${extension}</code>. Please use <code>.md</code> or <code>.tex</code>.</div>`;
+      } catch (error) {
+        root.innerHTML = `<div class="error">Could not load article source <code>${source}</code>.<br/>${error.message}</div>`;
+      }
+    })();
+  </script>
+
+  <script>
+    window.MathJax = {
+      tex: { inlineMath: [['$', '$'], ['\\(', '\\)']], displayMath: [['$$', '$$'], ['\\[', '\\]']] }
+    };
+  </script>
+  <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</body>
+</html>

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,8 +1,40 @@
 :root {
   --kk-accent: #3b82f6;
-  --kk-surface: #ffffff;
-  --kk-surface-muted: #f6f7fb;
+  --kk-surface: #f2f5fb;
+  --kk-surface-muted: #e9eef6;
   --kk-shadow: 0 18px 50px rgba(15, 23, 42, 0.12);
+}
+
+
+.theme-icon-btn {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.theme-icon-btn i {
+  font-size: 1rem;
+}
+
+#about .article-style a,
+.news-item a {
+  color: #1565c0;
+  text-decoration: none;
+}
+
+body.dark #about .article-style a,
+body.dark .news-item a {
+  color: #bbdefb;
+}
+
+#about .article-style a:hover,
+#about .article-style a:focus,
+.news-item a:hover,
+.news-item a:focus {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 #about .home-section-bg {
@@ -126,7 +158,28 @@
 }
 
 body.light {
-  background: #f3ede2;
+  background: #e9eef6;
+}
+
+body.light #about .home-section-bg {
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.10), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.10), transparent 60%);
+}
+
+body.light #profile {
+  background: #f2f5fb;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  box-shadow: 0 14px 36px rgba(15, 23, 42, 0.08);
+}
+
+body.light .news-item {
+  background: rgba(233, 238, 246, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+body.light .pub-list-item {
+  background: rgba(242, 245, 251, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.16);
 }
 
 body.dark .pub-figure img {

--- a/data/site-content.json
+++ b/data/site-content.json
@@ -15,7 +15,7 @@
       "text": "Febr 2025: Defended the PhD, officially a doctor!"
     },
     {
-      "icon": "far fa-pen-nib",
+      "icon": "far fa-file-alt",
       "text": "Jan 2025: New Arxiv",
       "link": {
         "label": "Multimodal Fusion Balancing Through Game-Theoretic Regularization",
@@ -25,7 +25,7 @@
       "suffix": "."
     },
     {
-      "icon": "far fa-pen-nib",
+      "icon": "far fa-file-alt",
       "text": "Dec 2024: Submitted the",
       "link": {
         "label": "PhD Thesis",
@@ -48,7 +48,7 @@
       "text": "Oct 2024: Seminar on Multimodal Competition soon on YouTube."
     },
     {
-      "icon": "far fa-pen-nib",
+      "icon": "far fa-file-alt",
       "text": "Jul 2024: New paper on BMVC24",
       "link": {
         "label": "Improving Multimodal Learning with Multi-Loss Gradient Modulation",
@@ -67,7 +67,7 @@
       "suffix": "on the role of ML/AI on future health systems."
     },
     {
-      "icon": "far fa-pen-nib",
+      "icon": "far fa-file-alt",
       "text": "March 2023:",
       "link": {
         "label": "CoRe-Sleep: A Multimodal Fusion Framework for Time Series Robust to Imperfect Modalities",

--- a/index.html
+++ b/index.html
@@ -164,17 +164,10 @@
 <!--                        <a class="nav-link js-search" href="#" aria-label="Search"><i class="fas fa-search"-->
 <!--                                                                                      aria-hidden="true"></i></a>-->
 <!--                    </li>-->
-                    <li class="nav-item dropdown theme-dropdown">
-                        <a href="#" class="nav-link" data-toggle="dropdown" aria-haspopup="true"
-                           aria-label="Display preferences">
-                            <i class="fas fa-moon" aria-hidden="true"></i>
-                        </a>
-                        <div class="dropdown-menu">
-<!--                            TODO: Change this to go from dark-default to light only, not auto-->
-                            <a href="#" class="dropdown-item js-set-theme-light">
-                                <span>Light</span>
-                            </a>
-                        </div>
+                    <li class="nav-item">
+                        <button id="main-theme-toggle" class="nav-link theme-icon-btn" type="button" aria-label="Toggle dark and light mode" title="Switch to light mode">
+                            <i id="main-theme-toggle-icon" class="fas fa-sun" aria-hidden="true"></i>
+                        </button>
                     </li>
                 </ul>
             </div>
@@ -253,6 +246,11 @@
                                 </a>
                             </li>
 
+                            <li>
+                                <a href="https://www.youtube.com/" target="_blank" rel="noopener" aria-label="youtube">
+                                    <i class="fab fa-youtube big-icon"></i>
+                                </a>
+                            </li>
 
                             <li>
                                 <a href="https://www.linkedin.com/in/konstantinos-kontras-771855152/" target="_blank" rel="noopener"
@@ -541,7 +539,7 @@
                         </div>
                         <div class="pub-content">
                             <div class="pub-title">
-                                <a href="phil_link">
+                                <a href="./articles/philosophical/phmind_intelligence.html?src=phmind_intelligence.md">
                                     The Metabolic Mind: Reclaiming the Conditions of Intelligence
                                 </a>
                             </div>
@@ -848,6 +846,32 @@
         </div>
     </div>
 </div>
+<script>
+(() => {
+  const storageKey = 'main-site-theme';
+  const toggleButton = document.getElementById('main-theme-toggle');
+  const icon = document.getElementById('main-theme-toggle-icon');
+  if (!toggleButton || !icon) return;
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = localStorage.getItem(storageKey);
+  const initialTheme = savedTheme || (document.body.classList.contains('dark') ? 'dark' : (prefersDark ? 'dark' : 'light'));
+
+  function setTheme(theme) {
+    document.body.classList.remove('dark', 'light');
+    document.body.classList.add(theme);
+    icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+    toggleButton.title = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+    localStorage.setItem(storageKey, theme);
+  }
+
+  setTheme(initialTheme);
+  toggleButton.addEventListener('click', () => {
+    const next = document.body.classList.contains('dark') ? 'light' : 'dark';
+    setTheme(next);
+  });
+})();
+</script>
 <script src="./js/wowchemy-publication.js" type="module"></script>
 <script src="./js/site-content.js"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Further reduce the remaining stark white areas in the homepage light theme so surfaces feel softer and more modern. 
- Make profile, news and publication cards visually consistent with the muted site surface and accent tones. 
- Add a standalone philosophical article viewer page and wire a persistent, single-button theme toggle for the main site. 
- Update site content icons and social links to better reflect published items and available channels.

### Description
- Tuned root variables in `css/custom.css` by changing `--kk-surface` to `#f2f5fb` and `--kk-surface-muted` to `#e9eef6`, and set `body.light` background to `#e9eef6` to cool the overall light palette. 
- Adjusted light-mode card styles in `css/custom.css` for `#profile`, `.news-item`, and `.pub-list-item` to use cooler muted backgrounds, subtle borders, and softened shadows. 
- Added a new article viewer page at `articles/philosophical/phmind_intelligence.html` that loads markdown/TeX sources, handles references, and supports theme toggling for that page. 
- Simplified the header theme control in `index.html` by replacing the dropdown with a single toggle button and added a persistent theme script (`main-site-theme`) that remembers the choice; updated a publication link to point to the new article page and added a YouTube social icon. 
- Updated `data/site-content.json` to replace several `far fa-pen-nib` icons with `far fa-file-alt` for news items.

### Testing
- Confirmed changed selectors and color values with `rg -n -- "--kk-surface|--kk-surface-muted|body.light \{|body.light #profile|body.light \.news-item|body.light \.pub-list-item" css/custom.css`, which returned the expected matches. (succeeded) 
- Served the site locally with `python -m http.server 4173` and verified assets loaded without errors blocking the visual changes. (succeeded) 
- Captured a full-page light-mode screenshot via a Playwright script after toggling theme, and inspected the artifact to validate the softer light palette. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab3339b608332bf590d6317b6140c)